### PR TITLE
keep the previous set camera convention as default

### DIFF
--- a/src/pointCloudEditorProvider.ts
+++ b/src/pointCloudEditorProvider.ts
@@ -717,6 +717,9 @@ export class PointCloudEditorProvider implements vscode.CustomReadonlyEditorProv
         case 'saveDefaultDepthSettings':
           await this.handleSaveDefaultDepthSettings(message);
           break;
+        case 'saveCameraConvention':
+          await this.context.globalState.update('defaultCameraConvention', message.convention);
+          break;
         case 'requestDefaultDepthSettings':
           await this.handleRequestDefaultDepthSettings(webviewPanel);
           break;
@@ -2713,13 +2716,23 @@ export class PointCloudEditorProvider implements vscode.CustomReadonlyEditorProv
             convention: 'opengl',
           };
 
+      const viewConvention = this.context.globalState.get('defaultCameraConvention') as
+        | string
+        | undefined;
+
       // Send settings back to webview
       webviewPanel.webview.postMessage({
         type: 'defaultDepthSettings',
         settings: filteredSettings,
+        viewConvention,
       });
 
-      console.log('Sent default depth settings to webview:', filteredSettings);
+      console.log(
+        'Sent default depth settings to webview:',
+        filteredSettings,
+        'viewConvention:',
+        viewConvention
+      );
     } catch (error) {
       console.error('Failed to load default depth settings:', error);
       // Send default fallback settings

--- a/website/src/main.ts
+++ b/website/src/main.ts
@@ -2523,6 +2523,9 @@ class PointCloudVisualizer {
     if (opencvBtn) {
       opencvBtn.addEventListener('click', () => {
         this.setOpenCVCameraConvention();
+        if (this.vscode) {
+          this.vscode.postMessage({ type: 'saveCameraConvention', convention: 'opencv' });
+        }
       });
     }
 
@@ -2530,6 +2533,9 @@ class PointCloudVisualizer {
     if (openglBtn) {
       openglBtn.addEventListener('click', () => {
         this.setOpenGLCameraConvention();
+        if (this.vscode) {
+          this.vscode.postMessage({ type: 'saveCameraConvention', convention: 'opengl' });
+        }
       });
     }
 
@@ -2691,10 +2697,16 @@ class PointCloudVisualizer {
           break;
         case 'c':
           this.setOpenCVCameraConvention();
+          if (this.vscode) {
+            this.vscode.postMessage({ type: 'saveCameraConvention', convention: 'opencv' });
+          }
           e.preventDefault();
           break;
         case 'b':
           this.setOpenGLCameraConvention();
+          if (this.vscode) {
+            this.vscode.postMessage({ type: 'saveCameraConvention', convention: 'opengl' });
+          }
           e.preventDefault();
           break;
         case 't':
@@ -11713,6 +11725,13 @@ class PointCloudVisualizer {
         depthBias: message.settings.depthBias !== undefined ? message.settings.depthBias : 0.0,
       };
       console.log('✅ Loaded default depth settings from extension:', this.defaultDepthSettings);
+
+      // Apply saved camera view convention if present
+      if (message.viewConvention === 'opencv') {
+        this.setOpenCVCameraConvention();
+      } else if (message.viewConvention === 'opengl') {
+        this.setOpenGLCameraConvention();
+      }
 
       // Update any existing depth file forms to use new defaults
       this.refreshDepthFileFormsWithDefaults();


### PR DESCRIPTION
Fixes suggestion from #2 

Now when switching to the opencv camera convention, saving the setting for the next point cloud.